### PR TITLE
Daniel commander prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A small node script which uses the Asana API to remove external users (ie withou
 
 ## To Develop
 
-* Install node
-* Clone this repository
-* Run `npm install`
+*   Install node
+*   Clone this repository
+*   Run `npm install`
 
 To test, run `npm run test`.
 
@@ -16,26 +16,37 @@ To build binarys, use `npm run build`.
 
 ### Prerequisites
 
-* Create a [service account](https://asana.com/guide/help/premium/service-accounts) in the organization (preferred, an admin PAT will also work)
-* Export a csv of Organization Members from the [Organization settings panel](https://asana.com/guide/help/premium/admins#gl-console) or – if you are an Asana eng – obtain a signed url for csv export of the members of the domain.
+*   Create a [service account](https://asana.com/guide/help/premium/service-accounts) in the organization (preferred, an admin PAT will also work)
+*   Export a csv of Organization Members from the [Organization settings panel](https://asana.com/guide/help/premium/admins#gl-console) or – if you are an Asana eng – obtain a signed url for csv export of the members of the domain.
 
 ### Running
 
-Run as a node script:
-`node depro-inactive-guests.js`
+There are two ways to run the script.
 
-Or simply open the built binary for your OS.
+### Providing options in arguments
+
+You can run the script by setting all required options:
+
+Dry run (displays which users would be deprovisioned):
+
+> `node index.js --auth <service account token> --csv <csv export url or file path> --organization_id <organization id> --threshold <# of inactive days>`
+
+Actually deprovision those users:
+
+> `node index.js --auth <service account token> --csv <csv export url or file path> --organization_id <organization id> --threshold <# of inactive days> --mode action`
+
+### Entering options in respons to prompts
+
+Or you can run the script without options and simply type in the correct information information when prompted:
+
+> `node index.js`
+
+Note that this is the same as executing one of the built binaries.
 
 The script will prompt you for the information it needs:
 
-* Serivce account token
-* URL or absolute file path to a .csv file
-* Organization ID
-* Threshold (number of inactive days we count as being an "inactive guest")
-* Mode ("dry" run or "action" run)
-
-Dry run (displays which users would be deprovisioned):
-> `node index.js --auth <service account token> --csv <csv export url or file path> --domain <organization id> --threshold <# of inactive days>`
-
-Actually deprovision those users:
-> `node index.js --auth <service account token> --csv <csv export url or file path> --domain <organization id> --threshold <# of inactive days> --mode action`
+*   Serivce account token
+*   URL or absolute file path to a .csv file
+*   Organization ID
+*   Threshold (number of inactive days we count as being an "inactive guest")
+*   Mode ("dry" run or "action" run)

--- a/depro-inactive-guests.js
+++ b/depro-inactive-guests.js
@@ -2,6 +2,7 @@ const asana = require("asana");
 const csv = require("csv-parser");
 const moment = require("moment");
 const request = require("request-promise");
+const commander = require("commander");
 const prompt = require("prompt");
 const fs = require("fs");
 
@@ -86,72 +87,113 @@ const usersToDeprovision = (csv, days) => {
     });
 };
 
-const main = () => {
-    // 1. Define schema
-    const schema = {
-        properties: {
-            token: {
-                message: "please enter a valid service account token",
-                pattern: /^0\//,
-                required: true
-            },
-            csv: {
-                message: "absolute path or url to csv file",
-                required: true
-            },
-            organization_id: {
-                message: "please enter a valid organization id",
-                pattern: /^[1-9]\d*$/,
-                required: true
-            },
-            threshold: {
-                message: "number of days inactive",
-                required: true
-            },
-            mode: {
-                message: "mode (dry or action)",
-                required: false
-            }
+const processInputs = inputs => {
+    const csvData = inputs.csv.includes("https://")
+        ? loadRemoteCsv(inputs.csv)
+        : loadLocalCsv(inputs.csv);
+
+    // Create Asana client
+    const asanaClient = createAsanaClient(inputs.auth);
+
+    // Set up deprovision function
+    const deprovision = deprovisionFunc(asanaClient, inputs.organization_id);
+
+    // Deprovision or log users
+    usersToDeprovision(csvData, inputs.threshold).then(emails => {
+        if (emails.length > 0) {
+            emails.forEach(email => {
+                if (inputs.mode === "action") {
+                    console.log("Deprovisioning", email);
+                    deprovision(email);
+                } else {
+                    console.log("Planning to deprovision", email);
+                }
+            });
+        } else {
+            console.log("No one will be deprovisioned.");
         }
-    };
-
-    // 2. Prompt user for inputs
-    prompt.colors = false;
-    prompt.message = "";
-    prompt.start();
-
-    prompt.get(schema, (err, inputs) => {
-        if (err) {
-            throw err;
-        }
-
-        // 3. Process CSV
-        const csvData = inputs.csv.includes("https://")
-            ? loadRemoteCsv(inputs.csv)
-            : loadLocalCsv(inputs.csv);
-
-        // 4. Create Asana client
-        const asanaClient = createAsanaClient(inputs.token);
-
-        // 5. Set up deprovision function
-        const deprovision = deprovisionFunc(asanaClient, inputs.organization_id);
-
-        // 6. Deprovision users
-        usersToDeprovision(csvData, inputs.threshold).then(emails => {
-            if (emails.length > 0) {
-                emails.forEach(email => {
-                    if (inputs.mode === "action") {
-                        console.log("Deprovisioning", email);
-                        deprovision(email);
-                    } else {
-                        console.log("Planning to deprovision", email);
-                    }
-                });
-            } else {
-                console.log("No one will be deprovisioned.");
-            }
-        });
     });
+};
+
+const main = () => {
+    // 1. Take options if we have them
+    commander
+        .version("0.0.3")
+        .option("-a, --auth <token>", "Service account token")
+        .option("-c, --csv <path>", "Path to member csv file")
+        .option("-o, --organization_id <organization_id>", "Organization or Workspace domain ID")
+        .option("-t, --threshold <#>", "# of days inactive threshold", parseInt)
+        .option("-m, --mode ['dry' or 'action']", "mode to run the script in")
+        .parse(process.argv);
+
+    if (commander.rawArgs.length > 2) {
+        // We've been given options, lets check those and then and then process those through
+        if (!commander.auth) {
+            console.log("Please set the `--auth` option with a service account token");
+            return;
+        }
+        if (!commander.csv) {
+            console.log("Please set the`--csv` option with a path or URL to a CSV file");
+            return;
+        }
+        if (!commander.organization_id) {
+            console.log("Please set a the `--domain` option with your domain ID");
+            return;
+        }
+        if (!commander.threshold) {
+            console.log(
+                "Please set a the `--threshold` option with the number of days of inactivity you'd like to count as being inactive"
+            );
+            return;
+        }
+        if (commander.mode !== "action") {
+            console.log(
+                "In dry-run mode. set --mode option to 'action' to actually deprovision users"
+            );
+        }
+
+        processInputs(commander);
+    } else {
+        // If we have no options, prompt the user for the inputs we need.
+        const schema = {
+            properties: {
+                auth: {
+                    message: "please enter a valid service account token",
+                    pattern: /^0\//,
+                    required: true
+                },
+                csv: {
+                    message: "absolute path or url to csv file",
+                    required: true
+                },
+                organization_id: {
+                    message: "please enter a valid organization id",
+                    pattern: /^[1-9]\d*$/,
+                    required: true
+                },
+                threshold: {
+                    message: "number of days inactive",
+                    required: true
+                },
+                mode: {
+                    message: "mode (dry or action)",
+                    required: false
+                }
+            }
+        };
+
+        // 2. Prompt user for inputs
+        prompt.colors = false;
+        prompt.message = "";
+        prompt.start();
+
+        prompt.get(schema, (err, inputs) => {
+            if (err) {
+                throw err;
+            }
+            processInputs(inputs);
+        });
+    }
 };
 
 main();


### PR DESCRIPTION
Ugh I realized its probably not a great idea to remove the ability to give the script all the information it needs up front in the form of options. Probably much easier to automate the script when you are able to do that.

So I've given the script some control flow. If the user provides arguments then we process the options they set, if they don't provide any options then we prompt them and process their standard input.

I think this makes the script ergonomic for non-technical users (and allows us to build a usable binary so they don't have to install node and npm install) and for technical users who may want to automate calling the script.